### PR TITLE
Allow input also in cram format. Update rust-htslib.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Peter Edge <edge.peterj@gmail.com>"]
 
 [dependencies]
 bio = "0.25.0"
-rust-htslib = "0.22.0"
+rust-htslib = "0.24.0"
 clap = "2.26.2"
 chrono = "0.4"
 rand = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Peter Edge <edge.peterj@gmail.com>"]
 
 [dependencies]
 bio = "0.25.0"
-rust-htslib = "0.24.0"
+rust-htslib = "0.26.0"
 clap = "2.26.2"
 chrono = "0.4"
 rand = "0.4"

--- a/src/call_potential_snvs.rs
+++ b/src/call_potential_snvs.rs
@@ -8,7 +8,7 @@ use bio::io::fasta;
 use bio::stats::{LogProb, Prob};
 use rust_htslib::bam;
 use rust_htslib::bam::pileup::Indel;
-use rust_htslib::prelude::*;
+use rust_htslib::bam::Read;
 
 use errors::*;
 //use std::str;

--- a/src/estimate_read_coverage.rs
+++ b/src/estimate_read_coverage.rs
@@ -9,7 +9,7 @@ extern crate rust_htslib;
 // use declarations
 use errors::*;
 use rust_htslib::bam;
-use rust_htslib::prelude::*;
+use rust_htslib::bam::Read;
 use util::{get_interval_lst, print_time, GenomicInterval};
 
 /// Calculates the mean coverage of the input BAM file over the input region

--- a/src/extract_fragments.rs
+++ b/src/extract_fragments.rs
@@ -277,7 +277,6 @@ pub fn find_anchors(
             >= bam_record
                 .cigar()
                 .end_pos()
-                .chain_err(|| "Error while accessing CIGAR end position")?
         || (var_interval.end_pos as i32) < bam_record.pos()
     {
         eprintln!(
@@ -291,7 +290,6 @@ pub fn find_anchors(
             bam_record
                 .cigar()
                 .end_pos()
-                .chain_err(|| "Error while accessing CIGAR end position")?
         );
 
         bail!(ErrorKind::AnchorRangeOutsideRead);
@@ -410,7 +408,10 @@ pub fn find_anchors(
                             found_anchor_left = true;
                             break;
                         }
-
+                        
+                        if (left_anchor_ref ==  0 ) || ( left_anchor_read == 0 ) {
+                            break;
+                        }
                         left_anchor_ref -= 1;
                         left_anchor_read -= 1;
                     }
@@ -1005,7 +1006,6 @@ pub fn extract_fragments(
             let end_pos = record
                 .cigar()
                 .end_pos()
-                .chain_err(|| "Error while accessing CIGAR end position")?
                 - 1;
 
             let bam_cig: CigarStringView = record.cigar();

--- a/src/haplotype_assembly.rs
+++ b/src/haplotype_assembly.rs
@@ -93,11 +93,11 @@ pub fn separate_bam_reads_by_haplotype(
     let unassigned_bam_file = format!("{}.unassigned.bam", &hap_bam_prefix);
 
     let header = bam::Header::from_template(&bam_ix.header());
-    let mut h1_bam = bam::Writer::from_path(&h1_bam_file, &header)
+    let mut h1_bam = bam::Writer::from_path(&h1_bam_file, &header,bam::Format::BAM)
         .chain_err(|| ErrorKind::BamWriterOpenError(h1_bam_file))?;
-    let mut h2_bam = bam::Writer::from_path(&h2_bam_file, &header)
+    let mut h2_bam = bam::Writer::from_path(&h2_bam_file, &header,bam::Format::BAM)
         .chain_err(|| ErrorKind::BamWriterOpenError(h2_bam_file))?;
-    let mut unassigned_bam = bam::Writer::from_path(&unassigned_bam_file, &header)
+    let mut unassigned_bam = bam::Writer::from_path(&unassigned_bam_file, &header,bam::Format::BAM)
         .chain_err(|| ErrorKind::BamWriterOpenError(unassigned_bam_file))?;
 
     for iv in interval_lst {

--- a/src/main.rs
+++ b/src/main.rs
@@ -408,9 +408,6 @@ fn run() -> Result<()> {
         "Variant output file already exists. Rerun with -F option to force overwrite."
     );
 
-    // ensure that BAM file is indexed
-    let bai_str = bamfile_name.clone() + ".bai";
-    ensure!(Path::new(&bai_str).is_file(), "BAM file must be indexed with samtools index. Index file should have same name as BAM file with .bai appended.");
 
     // ensure that FASTA file is indexed
     let fai_str = fasta_file.clone() + ".fai";

--- a/src/variants_and_fragments.rs
+++ b/src/variants_and_fragments.rs
@@ -197,7 +197,9 @@ pub fn parse_vcf_potential_variants(
         // get the alleles from the vcf record as well
 
         let rid = record.rid().chain_err(|| "Error accessing vcf RID")?;
-        let chrom: String = u8_to_string(vcfh.header().rid2name(rid))?;
+
+        let chrom_result = vcfh.header().rid2name(rid);
+        let chrom: String = u8_to_string(chrom_result.unwrap())?;
 
         if !chrom2tid.contains_key(&chrom) {
             eprintln!(


### PR DESCRIPTION
Enable cram input by updating rust-htslib and removing check for bai index. Htslib update required downstream change of one line.  This will crash gracefully if the index doesn't exist.