### PR TITLE
replace addlogs() with table-based approximation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,7 @@ fn main() {
         .file("src/hapcut2/readinputbuffers.c")
         .file("src/hapcut2/pointerheap.c")
         .file("src/hapcut2/hapcut2.c")
+        .file("src/hapcut2/logsum10.c")
         .compile("hapcut2");
 
     /*cc::Build::new()

--- a/src/hapcut2/common.h
+++ b/src/hapcut2/common.h
@@ -2,6 +2,7 @@
 #ifndef _COMMON_H
 #define _COMMON_H
 #include <stdint.h>
+#include "logsum10.h"
 
 //Tue May 29 23:13:29 PDT 2007
 extern int QVoffset;
@@ -10,7 +11,8 @@ extern int MINQ;
 #define MAXBUF 100000
 
 // given a=log10(x) and b=log10(y), returns log10(x+y)
-#define addlogs(a, b) (((a) > (b)) ? ((a) + log10(1.0 + pow(10.0, (b) - (a)))) : ((b) + log10(1.0 + pow(10.0, (a) - (b)))))
+//#define addlogs(a, b) (((a) > (b)) ? ((a) + log10(1.0 + pow(10.0, (b) - (a)))) : ((b) + log10(1.0 + pow(10.0, (a) - (b)))))
+#define addlogs(a, b) esl_flogsum10(a, b)
 // given a=log10(x) and b=log10(y), returns log10(x-y)
 #define subtractlogs(a, b) (((a) > (b)) ? ((a) + log10(1.0 - pow(10, (b) - (a)))) : ((b) + log10(1.0 - pow(10.0, (a) - (b)))))
 

--- a/src/hapcut2/hapcut2.c
+++ b/src/hapcut2/hapcut2.c
@@ -10,6 +10,7 @@
 #include "fragmatrix.h"
 #include "pointerheap.h"
 #include "readinputbuffers.h"
+#include "logsum10.h"
 
 // Printing related
 int VERBOSE = 0;
@@ -28,6 +29,7 @@ int LONG_READS = 1;
 
 int hapcut2(char** fragmentbuffer, int fragments, int snps, char* HAP1, int* PS) {
     // IMP NOTE: all SNPs start from 1 instead of 0 and all offsets are 1+
+    esl_flogsum10_init();
 
     srand(1);
     if (VERBOSE) fprintf_time(stderr, "Calling Max-Likelihood-Cut based haplotype assembly algorithm\n");

--- a/src/hapcut2/logsum10.c
+++ b/src/hapcut2/logsum10.c
@@ -1,0 +1,63 @@
+#include <stdlib.h>
+#include "logsum10.h"
+
+// statically allocate the lookup table
+float flogsum10_lookup[p7_LOGSUMTEN_TBL]; 
+
+// initialize
+int esl_flogsum10_init(void)
+{
+  static int firsttime = TRUE;
+  if (!firsttime) {
+      return eslOK;
+  }
+  firsttime = FALSE;
+
+  int i;
+  for (i = 0; i < p7_LOGSUMTEN_TBL; i++) {
+    flogsum10_lookup[i] = log10(1. + pow(10., (double) -i / p7_LOGSUMTEN_SCALE));
+  }
+  return eslOK;
+}
+
+// exact calculation that this package approximates
+float exact_logsum10(float a, float b)
+{
+    return log10(pow(10, a) + pow(10, b));
+}
+
+// calculate the error between the exact and approximate functions
+float esl_flogsum_10_error(float a, float b)
+{
+  float approx = esl_flogsum10(a,b);
+  float exact = exact_logsum10(a, b);
+  return (pow(10, approx) - pow(10, exact));
+}
+
+//
+// Code below is conditionally compiled when this symbol is defined
+//
+#ifdef LOGSUM10_EXAMPLE
+/* gcc -o example -g -O2 -I. -L. -DLOGSUM10_EXAMPLE logsum.c -lm
+ * ./example -0.5 -0.5
+ */
+
+int
+main(int argc, char **argv)
+{
+  float a = atof(argv[1]);
+  float b = atof(argv[2]);
+  float result;
+
+  esl_flogsum10_init();
+  result = esl_flogsum10(a, b);
+  printf("esl_flogsum10(%f,%f) = %f\n", a, b, result);
+
+  result = exact_logsum10(a, b);
+  printf("log10(10^%f + 10^%f) = %f\n", a, b, result);
+
+  printf("Absolute error in probability: %f\n", esl_flogsum_10_error(a,b));
+  return eslOK;
+}
+#endif /*p7LOGSUM10_EXAMPLE*/
+

--- a/src/hapcut2/logsum10.h
+++ b/src/hapcut2/logsum10.h
@@ -1,0 +1,42 @@
+//
+// logsum10 -- a port of Sean Eddy's fast table-driven log sum, converted to log base10
+// This code was originally part of HMMER. This version is used with
+// Sean Eddy's permission as public domain code.
+//
+#ifndef LOGSUMTEN_H
+#define LOGSUMTEN_H
+#include <assert.h>
+#include <stdio.h>
+#include <math.h>
+
+/* p7_LOGSUM10_SCALE defines the precision of the calculation; the
+ * default of 1000.0 means rounding differences to the nearest 0.001
+ * nat. p7_LOGSUM10_TBL defines the size of the lookup table; the
+ * default of 16000 means entries are calculated for differences of 0
+ * to 16.000 nats (when p7_LOGSUM10_SCALE is 1000.0).  e^{-p7_LOGSUM10_TBL /
+ * p7_LOGSUM10_SCALE} should be on the order of the machine FLT_EPSILON,
+ * typically 1.2e-7.
+ */
+#define p7_LOGSUMTEN_TBL   16000
+#define p7_LOGSUMTEN_SCALE 1000.f
+#define ESL_MAX(a,b)    (((a)>(b))?(a):(b))
+#define ESL_MIN(a,b)    (((a)<(b))?(a):(b))
+#define eslINFINITY     INFINITY
+#define TRUE            1
+#define FALSE           0
+#define eslOK           1
+
+// initialize the lookup table
+// this must be called before any calls to esl_flogsum10
+int esl_flogsum10_init(void);
+
+// approximation to log(10^a + 10^b)
+static inline float esl_flogsum10(float a, float b)
+{
+  extern float flogsum10_lookup[p7_LOGSUMTEN_TBL]; 
+  const float max = ESL_MAX(a, b);
+  const float min = ESL_MIN(a, b);
+  return (min == -eslINFINITY || (max-min) >= 15.7f) ? max : max + flogsum10_lookup[(int)((max-min)*p7_LOGSUMTEN_SCALE)];
+}
+
+#endif


### PR DESCRIPTION
Hi @pjedge and @vibansal,

I was running longshot this week, and noticed that a lot of the runtime is spent in hapcut2, specifically the`addlogs()` function. This PR replaces `addlogs()` with a fast table-driven approximation derived from @cryptogenomicon's method (in this case, I changed it to base-10 to match your code). This gives a pretty dramatic improvement in runtime on a 10MB segment of chromosome 20:

`addlogs()`:
```
[...]
2020-02-14 09:25:22 Calling initial genotypes using pair-HMM realignment...
2020-02-14 09:25:22 Iteratively assembling haplotypes and refining genotypes...
2020-02-14 09:25:22    Round 1 of haplotype assembly...
2020-02-14 09:25:23    (Before HapCUT2) Total phased heterozygous SNVs: 14937  Total likelihood (phred): 8297096.17
2020-02-14 09:33:51    (After HapCUT2)  Total phased heterozygous SNVs: 14937  Total likelihood (phred): 4559974.35
2020-02-14 09:33:54    (After Greedy)   Total phased heterozygous SNVs: 14937  Total likelihood (phred): 4001198.53
2020-02-14 09:33:54    Round 2 of haplotype assembly...
2020-02-14 09:33:54    (Before HapCUT2) Total phased heterozygous SNVs: 8988  Total likelihood (phred): 4001198.53
2020-02-14 09:39:06    (After HapCUT2)  Total phased heterozygous SNVs: 8988  Total likelihood (phred): 3999102.35
2020-02-14 09:39:07    (After Greedy)   Total phased heterozygous SNVs: 8988  Total likelihood (phred): 3998677.32
2020-02-14 09:39:07 Printing VCF file...
```

logsum approximation:
```
[...]
2020-02-14 09:42:01 Calling initial genotypes using pair-HMM realignment...
2020-02-14 09:42:01 Iteratively assembling haplotypes and refining genotypes...
2020-02-14 09:42:01    Round 1 of haplotype assembly...
2020-02-14 09:42:01    (Before HapCUT2) Total phased heterozygous SNVs: 14937  Total likelihood (phred): 8297096.17
2020-02-14 09:43:12    (After HapCUT2)  Total phased heterozygous SNVs: 14937  Total likelihood (phred): 4559974.35
2020-02-14 09:43:15    (After Greedy)   Total phased heterozygous SNVs: 14937  Total likelihood (phred): 4001198.53
2020-02-14 09:43:15    Round 2 of haplotype assembly...
2020-02-14 09:43:15    (Before HapCUT2) Total phased heterozygous SNVs: 8988  Total likelihood (phred): 4001198.53
2020-02-14 09:43:48    (After HapCUT2)  Total phased heterozygous SNVs: 8988  Total likelihood (phred): 3999102.35
2020-02-14 09:43:50    (After Greedy)   Total phased heterozygous SNVs: 8988  Total likelihood (phred): 3998677.32
2020-02-14 09:43:50 Printing VCF file...
```

In this case the first round of hapcut2 has gone from 508s to 71s. The set of variants, and their qualities, are the same between the two runs but the VCFs are formatted slightly differently (the order of values in one tag is different):

```
addlogs.vcf:PH=235.06,0.00,467.47,200.65;
approx.vcf: PH=235.06,467.47,0.00,200.65;
```

I'm not sure if this difference is significant, and I've only performed limited tests so far, but I wanted to send the PR for feedback anyway.

Jared