### PR TITLE
Fixed resolve_cigar2 issue due to problems with old rust-htslib dependency (#44)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Peter Edge <edge.peterj@gmail.com>"]
 
 [dependencies]
 bio = "0.25.0"
-rust-htslib = "0.26.0"
+rust-htslib = "0.28.0"
 clap = "2.26.2"
 chrono = "0.4"
 rand = "0.4"

--- a/src/extract_fragments.rs
+++ b/src/extract_fragments.rs
@@ -36,6 +36,7 @@ use util::*;
 use variants_and_fragments::*;
 use std::u32;
 use std::usize;
+use std::convert::TryInto;
 
 static VERBOSE: bool = false;
 static IGNORE_INDEL_ONLY_CLUSTERS: bool = false;
@@ -276,8 +277,8 @@ pub fn find_anchors(
         || (var_interval.start_pos as i32)
             >= bam_record
                 .cigar()
-                .end_pos()
-        || (var_interval.end_pos as i32) < bam_record.pos()
+                .end_pos().try_into().unwrap()
+        || (var_interval.end_pos as i32) < bam_record.pos().try_into().unwrap()
     {
         eprintln!(
             "var_interval: {}\t{}\t{}",


### PR DESCRIPTION
See #44 
To reproduce the bug and the fix:

longshot --bam HG002_chr22_b38.sorted_MD_RG.bam --ref 
 GCA_000001405.15_GRCh38_no_alt_analysis_set.fna --out HG002_chr22_b38_longshot.vcf

Test data on google drive
bam - 4GB
https://drive.google.com/file/d/1Gy1RFMkCilC4S-binQRX1B_YMK0f_8QX/view?usp=sharing
bai
https://drive.google.com/file/d/1b3aphHymwJcBd7sZT5P_3EUUt6xJkERq/view?usp=sharing

Genome reference:
ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/001/405/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.gz



