### PR TITLE
Update rust-htslib to 0.38.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Peter Edge <edge.peterj@gmail.com>"]
 
 [dependencies]
 bio = "0.25.0"
-rust-htslib = "0.28.0"
+rust-htslib = "0.38.2"
 clap = "2.26.2"
 chrono = "0.4"
 rand = "0.4"

--- a/build.rs
+++ b/build.rs
@@ -31,5 +31,5 @@ fn main() {
 
         println!("cargo:rustc-flags=-L src/poa/spoa/build/lib/ -L /home/pedge/anaconda3/envs/tscc/lib -l spoa");
     */
-    println!("cargo:rustc-flags=-L /home/pedge/anaconda3/envs/tscc/lib");
+    // println!("cargo:rustc-flags=-L /home/pedge/anaconda3/envs/tscc/lib");
 }

--- a/src/call_potential_snvs.rs
+++ b/src/call_potential_snvs.rs
@@ -139,7 +139,7 @@ pub fn call_potential_snvs(
     // genomic intervals for each chromosome covering the entire genome
     for iv in interval_lst {
         bam_ix
-            .fetch(iv.tid as u32, iv.start_pos as u32, iv.end_pos as u32 + 1)
+            .fetch((iv.tid as u32, iv.start_pos as u32, iv.end_pos as u32 + 1))
             .chain_err(|| ErrorKind::IndexedBamFetchError)?;
         let bam_pileup = bam_ix.pileup();
 

--- a/src/estimate_alignment_parameters.rs
+++ b/src/estimate_alignment_parameters.rs
@@ -411,7 +411,7 @@ pub fn estimate_alignment_parameters(
 
     for iv in interval_lst {
         bam_ix
-            .fetch(iv.tid, iv.start_pos, iv.end_pos + 1)
+            .fetch((iv.tid, iv.start_pos, iv.end_pos + 1))
             .chain_err(|| ErrorKind::IndexedBamFetchError)?;
 
         for r in bam_ix.records() {

--- a/src/estimate_read_coverage.rs
+++ b/src/estimate_read_coverage.rs
@@ -56,7 +56,7 @@ pub fn calculate_mean_coverage(
 
     for iv in interval_lst {
         bam_ix
-            .fetch(iv.tid, iv.start_pos, iv.end_pos + 1)
+            .fetch((iv.tid, iv.start_pos, iv.end_pos + 1))
             .chain_err(|| ErrorKind::IndexedBamFetchError)?;
 
         // iterate over the BAM pileups for every position in this interval

--- a/src/extract_fragments.rs
+++ b/src/extract_fragments.rs
@@ -972,7 +972,7 @@ pub fn extract_fragments(
 
     for iv in interval_lst {
         bam_ix
-            .fetch(iv.tid, iv.start_pos, iv.end_pos + 1)
+            .fetch((iv.tid, iv.start_pos, iv.end_pos + 1))
             .chain_err(|| "Error seeking BAM file while extracting fragments.")?;
 
         for (_, r) in bam_ix.records().enumerate() {

--- a/src/haplotype_assembly.rs
+++ b/src/haplotype_assembly.rs
@@ -118,12 +118,12 @@ pub fn separate_bam_reads_by_haplotype<P: AsRef<std::path::Path>>(
         bam::IndexedReader::from_path(bamfile_name).chain_err(|| ErrorKind::IndexedBamOpenError)?;
 
     let header = bam::Header::from_template(&bam_ix.header());
-    let mut out_bam = bam::Writer::from_path(&out_bam_file, &header, bam::Format::BAM)
+    let mut out_bam = bam::Writer::from_path(&out_bam_file, &header, bam::Format::Bam)
         .chain_err(|| ErrorKind::BamWriterOpenError(out_bam_file.as_ref().display().to_string()))?;
 
     for iv in interval_lst {
         bam_ix
-            .fetch(iv.tid, iv.start_pos, iv.end_pos + 1)
+            .fetch((iv.tid, iv.start_pos, iv.end_pos + 1))
             .chain_err(|| ErrorKind::IndexedBamFetchError)?;
 
         for r in bam_ix.records() { // iterate over the reads overlapping the interval 'iv'
@@ -144,15 +144,14 @@ pub fn separate_bam_reads_by_haplotype<P: AsRef<std::path::Path>>(
                     .chain_err(|| ErrorKind::BamRecordWriteError(qname))?;
                 continue; // write filtered reads to bam file and continue
             }
-
             if h1.contains_key(&qname) {
-                record.push_aux(b"HP", &bam::record::Aux::Integer(1));
+                record.push_aux(b"HP", bam::record::Aux::I32(1));
                 record.push_aux(b"PS",
-                    &bam::record::Aux::Integer(*h1.get(&qname).unwrap() as i64));
+                    bam::record::Aux::I32(*h1.get(&qname).unwrap() as i32));
             } else if h2.contains_key(&qname) {
-                record.push_aux(b"HP", &bam::record::Aux::Integer(2));
+                record.push_aux(b"HP", bam::record::Aux::I32(2));
                 record.push_aux(b"PS",
-                    &bam::record::Aux::Integer(*h2.get(&qname).unwrap() as i64));
+                    bam::record::Aux::I32(*h2.get(&qname).unwrap() as i32));
             }
             out_bam
                 .write(&record)

--- a/src/util.rs
+++ b/src/util.rs
@@ -141,11 +141,11 @@ pub fn parse_region_string(
                 "--region start position must be greater than 0."
             );
             ensure!(
-                iv_start < tlen,
+                iv_start < tlen as u32,
                 "--region start position exceeds the length of the contig."
             );
             ensure!(
-                iv_end <= tlen,
+                iv_end <= tlen as u32,
                 "--region end position exceeds the length of the contig."
             );
 
@@ -177,7 +177,7 @@ pub fn parse_region_string(
                 tid: tid,
                 chrom: r_str,
                 start_pos: 0,
-                end_pos: tlen - 1,
+                end_pos: (tlen - 1) as u32,
             }))
         }
         None => Ok(None),
@@ -270,10 +270,10 @@ pub fn get_whole_genome_intervals(bam_file: &String) -> Result<Vec<GenomicInterv
             tid: tid as u32,
             chrom: name_string,
             start_pos: 0,
-            end_pos: header_view
+            end_pos: (header_view
                 .target_len(tid as u32)
                 .chain_err(|| format!("Error accessing target len for tid {}", tid))?
-                - 1,
+                - 1) as u32,
         });
     }
 


### PR DESCRIPTION
This PR updates the `rust-htslib` to version [0.38.2](https://crates.io/crates/rust-htslib/0.38.2) and updates relevant code to use the new ["improved API for accessing AUX fields in BAM records"](https://github.com/rust-bio/rust-htslib/blob/master/CHANGELOG.md#0370---2021-07-05).

This update may be required to fix compilation on OSX ([Bioconda package for longshot not building on OSX](https://app.circleci.com/pipelines/github/bioconda/bioconda-recipes/54189/workflows/2edc6465-85f6-4688-9dc1-aac2b5e398e7/jobs/171791?invite=true#step-107-348)):

```
15:00:04 BIOCONDA INFO (ERR) error: linking with `cc` failed: exit status: 1
15:00:04 BIOCONDA INFO (ERR)   |
15:00:04 BIOCONDA INFO (ERR)   = note: "cc" "-m64" "-arch" "x86_64" ..."-lclang_rt.osx" "-framework" "Security" "-framework" "CoreFoundation" "-framework" "SystemConfiguration" "-liconv" "-lSystem" "-lresolv" "-lc" "-lm" "-liconv" "-L" "/Users/distiller/project/miniconda/conda-bld/longshot_1634050390953/_build_env/lib/rustlib/x86_64-apple-darwin/lib" "-o" "/Users/distiller/project/miniconda/conda-bld/longshot_1634050390953/work/target/release/deps/longshot" "-Wl,-dead_strip" "-nodefaultlibs"
15:00:05 BIOCONDA INFO (ERR)   = note: Undefined symbols for architecture x86_64:
15:00:05 BIOCONDA INFO (ERR)             "_SSLCopyALPNProtocols", referenced from:
15:00:05 BIOCONDA INFO (ERR)                 _sectransp_connect_step2 in libcurl_sys-107389ef836d7c2a.rlib(sectransp.o)
15:00:05 BIOCONDA INFO (ERR)             "_SSLSetALPNProtocols", referenced from:
15:00:05 BIOCONDA INFO (ERR)                 _sectransp_connect_common in libcurl_sys-107389ef836d7c2a.rlib(sectransp.o)
15:00:05 BIOCONDA INFO (ERR)           ld: symbol(s) not found for architecture x86_64
15:00:05 BIOCONDA INFO (ERR)           clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Updating htslib seemed to fix a related issue for perbase: https://github.com/sstadick/perbase/pull/32

A more recent version of `rust-htslib` may pull a more recent version of `curl` (I think the dependency is specified [here](https://github.com/rust-bio/rust-htslib/blob/9e015636fa17b8f1e86ba26d26857917756995e4/Cargo.toml#L43))

Possible related curl issue and PR for OSX

- https://github.com/curl/curl/issues/3733
- https://github.com/curl/curl/pull/3769

--- 

FYI this is the first time I've played with Rust code, but I have some experience with C and C++. I relied heavily on the IntelliJ Rust plugin and compilation errors to try to fix issues arising from upgrading `htslib`. 

I've only had the chance to build and test on my Linux machine with the latest version of Rust available using `rustup` on a dataset of MinION reads aligned to a large DNA virus with variant calling using Medaka v1.4.3. A previous version of Longshot (v0.4.1) would produce an error when processing this dataset and others like it, so I'm really interested in v0.4.3 where the issues are addressed.

Please let me know if there's any changes you need.

Thanks! 